### PR TITLE
Fix/legacy reports doesnt export images

### DIFF
--- a/app/src/routes/v3/answers.router.js
+++ b/app/src/routes/v3/answers.router.js
@@ -148,7 +148,11 @@ class AnswerRouter {
 
     const imagePromises = [];
     for (const imageResponse of imageResponses) {
-      const imageUrls = imageResponse.value ?? [];
+      let imageUrls = imageResponse.value ?? [];
+      if (typeof imageUrls === "string") {
+        imageUrls = [imageUrls];
+      }
+
       for (const url of imageUrls) {
         imagePromises.push(axios.get(url, { responseType: "arraybuffer" }).then(res => res.data));
       }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       LOGGER_LEVEL: debug
       PORT: 3000
       AUTH_URL: https://staging-api.resourcewatch.org
-      CORE_API_URL: https://dev-fw-api.globalforestwatch.org/v3/gfw
+      CORE_API_URL: https://staging-fw-api.globalforestwatch.org/v3/gfw
       ALERTS_API_URL: "https://staging-data-api.globalforestwatch.org"
       GEOSTORE_API_URL: https://staging-api.resourcewatch.org/v1
       GFW_DATA_API_KEY: ${gfw_data_api_key}
@@ -34,7 +34,7 @@ services:
   test:
     build: .
     container_name: fw-exports-test
-    environment: 
+    environment:
       AREAS_API_URL: http://127.0.0.1:9000
       MONGODB_HOST: mongo
       MONGODB_PORT: 27017


### PR DESCRIPTION
## Changes
- Account for image responses being strings as it is in old reports

## Ticket
[GFW-1628](https://3sidedcube.atlassian.net/browse/GFW-1628)